### PR TITLE
refactor: use clap value_enum replace some trait

### DIFF
--- a/src/cli/base64.rs
+++ b/src/cli/base64.rs
@@ -1,6 +1,4 @@
-use std::{fmt, str::FromStr};
-
-use clap::Parser;
+use clap::{Parser, ValueEnum};
 use enum_dispatch::enum_dispatch;
 
 use crate::CmdExector;
@@ -20,7 +18,7 @@ pub enum Base64SubCommand {
 pub struct Base64EncodeOpts {
     #[arg(short, long, value_parser = verify_file, default_value = "-")]
     pub input: String,
-    #[arg(long, value_parser = parse_base64_format, default_value = "standard")]
+    #[arg(value_enum, long, default_value_t=Base64Format::Standard)]
     pub format: Base64Format,
 }
 
@@ -28,45 +26,14 @@ pub struct Base64EncodeOpts {
 pub struct Base64DecodeOpts {
     #[arg(short, long, value_parser = verify_file, default_value = "-")]
     pub input: String,
-    #[arg(long, value_parser = parse_base64_format, default_value = "standard")]
+    #[arg(long, value_enum, long, default_value_t=Base64Format::Standard)]
     pub format: Base64Format,
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, ValueEnum)]
 pub enum Base64Format {
     Standard,
-    UrlSafe,
-}
-
-fn parse_base64_format(format: &str) -> Result<Base64Format, anyhow::Error> {
-    format.parse()
-}
-
-impl FromStr for Base64Format {
-    type Err = anyhow::Error;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s {
-            "standard" => Ok(Base64Format::Standard),
-            "urlsafe" => Ok(Base64Format::UrlSafe),
-            _ => Err(anyhow::anyhow!("Invalid format")),
-        }
-    }
-}
-
-impl From<Base64Format> for &'static str {
-    fn from(format: Base64Format) -> Self {
-        match format {
-            Base64Format::Standard => "standard",
-            Base64Format::UrlSafe => "urlsafe",
-        }
-    }
-}
-
-impl fmt::Display for Base64Format {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", Into::<&str>::into(*self))
-    }
+    Urlsafe,
 }
 
 impl CmdExector for Base64EncodeOpts {

--- a/src/cli/csv.rs
+++ b/src/cli/csv.rs
@@ -1,10 +1,10 @@
 use crate::CmdExector;
 
 use super::verify_file;
-use clap::Parser;
-use std::{fmt, str::FromStr};
+use clap::{Parser, ValueEnum};
+use std::fmt;
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, ValueEnum)]
 pub enum OutputFormat {
     Json,
     Yaml,
@@ -18,7 +18,7 @@ pub struct CsvOpts {
     #[arg(short, long)] // "output.json".into()
     pub output: Option<String>,
 
-    #[arg(long, value_parser = parse_format, default_value = "json")]
+    #[arg(long,value_enum, default_value_t=OutputFormat::Json)]
     pub format: OutputFormat,
 
     #[arg(short, long, default_value_t = ',')]
@@ -39,33 +39,12 @@ impl CmdExector for CsvOpts {
     }
 }
 
-fn parse_format(format: &str) -> Result<OutputFormat, anyhow::Error> {
-    format.parse()
-}
-
-impl From<OutputFormat> for &'static str {
-    fn from(format: OutputFormat) -> Self {
-        match format {
-            OutputFormat::Json => "json",
-            OutputFormat::Yaml => "yaml",
-        }
-    }
-}
-
-impl FromStr for OutputFormat {
-    type Err = anyhow::Error;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s {
-            "json" => Ok(OutputFormat::Json),
-            "yaml" => Ok(OutputFormat::Yaml),
-            _ => Err(anyhow::anyhow!("Invalid format")),
-        }
-    }
-}
-
 impl fmt::Display for OutputFormat {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", Into::<&str>::into(*self))
+        let lowercase = match self {
+            OutputFormat::Json => "json",
+            OutputFormat::Yaml => "yaml",
+        };
+        write!(f, "{}", lowercase)
     }
 }

--- a/src/process/b64.rs
+++ b/src/process/b64.rs
@@ -11,7 +11,7 @@ pub fn process_encode(reader: &mut dyn Read, format: Base64Format) -> Result<Str
     reader.read_to_end(&mut buf)?;
     let encoded = match format {
         Base64Format::Standard => STANDARD.encode(&buf),
-        Base64Format::UrlSafe => URL_SAFE_NO_PAD.encode(&buf),
+        Base64Format::Urlsafe => URL_SAFE_NO_PAD.encode(&buf),
     };
 
     Ok(encoded)
@@ -25,7 +25,7 @@ pub fn process_decode(reader: &mut dyn Read, format: Base64Format) -> Result<Str
 
     let decoded = match format {
         Base64Format::Standard => STANDARD.decode(buf)?,
-        Base64Format::UrlSafe => URL_SAFE_NO_PAD.decode(buf)?,
+        Base64Format::Urlsafe => URL_SAFE_NO_PAD.decode(buf)?,
     };
     // TODO: decoded data might not be string (but for this example, we assume it is)
     Ok(String::from_utf8(decoded)?)
@@ -49,7 +49,7 @@ mod tests {
     fn test_process_decode() -> Result<()> {
         let input = "fixtures/b64.txt";
         let mut reader = get_reader(input)?;
-        let format = Base64Format::UrlSafe;
+        let format = Base64Format::Urlsafe;
         process_decode(&mut reader, format)?;
 
         Ok(())


### PR DESCRIPTION
use  value_enum replace some trait, At the same time, the help information is more friendly, and the enumeration types of parameters can be automatically listed.

```
Encode a string to base64

Usage: rcli base64 encode [OPTIONS]

Options:
  -i, --input <INPUT>    [default: -]
      --format <FORMAT>  [default: standard] [possible values: standard, urlsafe]
  -h, --help             Print help
```

```
Usage: rcli csv [OPTIONS] --input <INPUT>

Options:
  -i, --input <INPUT>          
  -o, --output <OUTPUT>        
      --format <FORMAT>        [default: json] [possible values: json, yaml]
  -d, --delimiter <DELIMITER>  [default: ,]
      --header                 
  -h, --help                   Print help
```

```

Usage: rcli text sign [OPTIONS] --key <KEY>

Options:
  -i, --input <INPUT>    [default: -]
  -k, --key <KEY>        
      --format <FORMAT>  [default: blake3] [possible values: blake3, ed25519]
  -h, --help             Print help
```
