### PR TITLE
Refactor CLI flags to support explicit disable options

### DIFF
--- a/src/cli/genpass.rs
+++ b/src/cli/genpass.rs
@@ -7,27 +7,27 @@ pub struct GenPassOpts {
     #[arg(short, long, default_value_t = 16)]
     pub length: u8,
 
-    #[arg(long, default_value_t = true)]
-    pub uppercase: bool,
+    #[arg(long, default_value_t = false)]
+    pub no_uppercase: bool,
 
-    #[arg(long, default_value_t = true)]
-    pub lowercase: bool,
+    #[arg(long, default_value_t = false)]
+    pub no_lowercase: bool,
 
-    #[arg(long, default_value_t = true)]
-    pub number: bool,
+    #[arg(long, default_value_t = false)]
+    pub no_number: bool,
 
-    #[arg(long, default_value_t = true)]
-    pub symbol: bool,
+    #[arg(long, default_value_t = false)]
+    pub no_symbol: bool,
 }
 
 impl CmdExector for GenPassOpts {
     async fn execute(self) -> anyhow::Result<()> {
         let ret = crate::process_genpass(
             self.length,
-            self.uppercase,
-            self.lowercase,
-            self.number,
-            self.symbol,
+            !self.no_uppercase,
+            !self.no_lowercase,
+            !self.no_number,
+            !self.no_symbol,
         )?;
         println!("{}", ret);
 


### PR DESCRIPTION
Changed existing CLI flags for password generation to `no_xxx` format to allow explicit disabling of character types. The transition includes changing `--uppercase` to `--no-uppercase` with its default set to false, similarly for `--lowercase`, `--number`, and `--symbol`. 

This modification addresses a significant limitation of the previous approach: 
- if the default were set to `false`, users would need to specify each option to enable it; 
- if set to `true`, **it would be impossible to disable them**.