### PR TITLE
fix: When running the genpass -l command, an error is reported when l…

### DIFF
--- a/src/cli/genpass.rs
+++ b/src/cli/genpass.rs
@@ -1,10 +1,11 @@
+use super::verify_length;
 use crate::CmdExector;
 use clap::Parser;
 use zxcvbn::zxcvbn;
 
 #[derive(Debug, Parser)]
 pub struct GenPassOpts {
-    #[arg(short, long, default_value_t = 16)]
+    #[arg(short, long, value_parser = verify_length, default_value_t = 16)]
     pub length: u8,
 
     #[arg(long, default_value_t = true)]

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -51,6 +51,15 @@ fn verify_path(path: &str) -> Result<PathBuf, &'static str> {
     }
 }
 
+fn verify_length(length: &str) -> Result<u8, &'static str> {
+    let len = length.parse::<u8>().map_err(|_| "Length is illegal")?;
+    if len >= 4 {
+        Ok(len)
+    } else {
+        Err("Length cannot be less than 4")
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
thread 'main' panicked at src/process/gen_pass.rs:36:17:
attempt to subtract with overflow
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace